### PR TITLE
Fix behavior of low-level keyboard hook

### DIFF
--- a/src/FlashCom/App.h
+++ b/src/FlashCom/App.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Input/LowLevelKeyboardHookHelper.h"
 #include "Models/DataModel.h"
 #include "Settings/SettingsManager.h"
 #include "View/HostWindow.h"
@@ -15,7 +16,8 @@ namespace FlashCom
     {
         static std::unique_ptr<App> CreateApp(const HINSTANCE& hInstance);
         int RunMessageLoop();
-        void HandleLowLevelKeyboardInput(WPARAM wParam, KBDLLHOOKSTRUCT* kb);
+        FlashCom::Input::LowLevelCallbackReturnKind HandleLowLevelKeyboardInput(
+            WPARAM wParam, KBDLLHOOKSTRUCT* kb);
         void ToggleVisibility();
 
     private:

--- a/src/FlashCom/Input/LowLevelKeyboardHookHelper.h
+++ b/src/FlashCom/Input/LowLevelKeyboardHookHelper.h
@@ -5,5 +5,11 @@
 
 namespace FlashCom::Input
 {
-    void SetGlobalLowLevelKeyboardCallback(std::function<void(WPARAM, KBDLLHOOKSTRUCT*)> callback);
+    enum class LowLevelCallbackReturnKind
+    {
+        Handled,
+        Unhandled,
+    };
+    void SetGlobalLowLevelKeyboardCallback(
+        std::function<LowLevelCallbackReturnKind(WPARAM, KBDLLHOOKSTRUCT*)> callback);
 }

--- a/src/FlashCom/main.cpp
+++ b/src/FlashCom/main.cpp
@@ -14,16 +14,18 @@ namespace
     HINSTANCE g_hInstance{ nullptr };
     std::unique_ptr<FlashCom::App> g_app{ nullptr };
 
-    void HandleLowLevelKeyboardInput(WPARAM wParam, KBDLLHOOKSTRUCT* kb)
+    FlashCom::Input::LowLevelCallbackReturnKind HandleLowLevelKeyboardInput(
+        WPARAM wParam, KBDLLHOOKSTRUCT* kb)
     {
         if (g_app)
         {
-            g_app->HandleLowLevelKeyboardInput(wParam, kb);
+            return g_app->HandleLowLevelKeyboardInput(wParam, kb);
         }
         else
         {
             SPDLOG_ERROR("HandleLowLevelKeyboardInput - Low level keyboard input unhandled, "
                 "callback not set.");
+            return FlashCom::Input::LowLevelCallbackReturnKind::Unhandled;
         }
     }
 


### PR DESCRIPTION
Fixes the FlashCom low-level keyboard hook to properly call the next hook when not handling the incoming events per [LowLevelKeyboardProc](https://learn.microsoft.com/en-us/windows/win32/winmsg/lowlevelkeyboardproc) guidelines.