### PR TITLE
⚙️ Improve settings parsing, add reload option

### DIFF
--- a/src/FlashCom/App.cpp
+++ b/src/FlashCom/App.cpp
@@ -132,6 +132,7 @@ namespace FlashCom
         m_hostWindow{ hInstance, L"FlashCom", std::bind(&App::HandleFocusLost, this) },
         m_trayIcon{ hInstance, {
             std::make_pair(std::wstring{ L"Settings" }, std::bind(&App::OnSettingsCommand, this)),
+            std::make_pair(std::wstring{ L"Reload" }, std::bind(&App::OnReloadCommand, this)),
             std::make_pair(std::wstring{ L"Exit" }, std::bind(&App::OnExitCommand, this))
         } },
         m_ui{ m_hostWindow, m_dataModel.get() }
@@ -194,6 +195,13 @@ namespace FlashCom
         ShellExecuteW(nullptr, L"explore",
             m_settingsManager.GetSettingsFilePath().parent_path().wstring().data(),
             nullptr, nullptr, SW_SHOWNORMAL);
+    }
+
+    void App::OnReloadCommand()
+    {
+        SPDLOG_INFO("App::OnReloadCommand");
+        LoadDataModel();
+        m_ui.Update();
     }
 
     void App::OnExitCommand()

--- a/src/FlashCom/App.h
+++ b/src/FlashCom/App.h
@@ -37,6 +37,7 @@ namespace FlashCom
         void Show();
         void Hide();
         void OnSettingsCommand();
+        void OnReloadCommand();
         void OnExitCommand();
     };
 }

--- a/src/FlashCom/App.h
+++ b/src/FlashCom/App.h
@@ -15,6 +15,7 @@ namespace FlashCom
     struct App
     {
         static std::unique_ptr<App> CreateApp(const HINSTANCE& hInstance);
+        void LoadDataModel();
         int RunMessageLoop();
         FlashCom::Input::LowLevelCallbackReturnKind HandleLowLevelKeyboardInput(
             WPARAM wParam, KBDLLHOOKSTRUCT* kb);

--- a/src/FlashCom/Models/DataModel.cpp
+++ b/src/FlashCom/Models/DataModel.cpp
@@ -2,9 +2,4 @@
 #include "DataModel.h"
 
 namespace FlashCom::Models
-{
-    DataModel::DataModel(std::unique_ptr<TreeNode>&& rootNode) :
-        RootNode{ std::move(rootNode) },
-        CurrentNode{ RootNode.get() }
-    { }
-}
+{ }

--- a/src/FlashCom/Models/DataModel.h
+++ b/src/FlashCom/Models/DataModel.h
@@ -5,10 +5,8 @@ namespace FlashCom::Models
 {
     struct DataModel
     {
-        DataModel(std::unique_ptr<TreeNode>&& rootNode);
-        DataModel(DataModel&& other) = default;
-
-        const std::unique_ptr<TreeNode> RootNode;
+        std::string LoadErrorMessage;
+        std::shared_ptr<TreeNode> RootNode;
         TreeNode* CurrentNode{ nullptr };
     };
 }

--- a/src/FlashCom/Settings/SettingsManager.cpp
+++ b/src/FlashCom/Settings/SettingsManager.cpp
@@ -10,8 +10,23 @@
 namespace
 {
     constexpr std::string_view c_settingsFileName{ "settings.json" };
+    // JSON property names
+    constexpr std::string_view c_commandsJsonProperty{ "commands" };
+    constexpr std::string_view c_commandNameJsonProperty{ "name" };
+    constexpr std::string_view c_commandKeyJsonProperty{ "key" };
+    constexpr std::string_view c_commandChildrenJsonProperty{ "children" };
+    constexpr std::string_view c_commandTypeJsonProperty{ "type" };
+    constexpr std::string_view c_commandExecuteFileJsonProperty{ "executeFile" };
+    constexpr std::string_view c_commandExecuteParametersJsonProperty{ "executeParameters" };
+    constexpr std::string_view c_commandUriJsonProperty{ "uri" };
+    constexpr std::string_view c_commandAumidJsonProperty{ "aumid" };
+    // JSON command node 'type' values
+    constexpr std::string_view c_commandTypeValueShellExecute{ "shellExecute" };
+    constexpr std::string_view c_commandTypeValueUri{ "uri" };
+    constexpr std::string_view c_commandTypeValueAumid{ "aumid" };
+    // Default settings.json contents
     constexpr std::string_view c_defaultSettingsFileContents{ R"({
-    "commandTree": [
+    "commands": [
         {
             "name": "Tools",
             "key": "T",
@@ -60,65 +75,192 @@ namespace
             .LocalFolder().Path().c_str() } / c_settingsFileName;
     }
 
-    std::unique_ptr<FlashCom::Models::TreeNode> ParseToTreeNode(const nlohmann::json& json)
+    bool IsValidKeyString(const std::string& key)
+    {
+        // Valid keys map to single vkey codes as defined in winuser.h and are not
+        // special characters or modifier keys.
+        // https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
+        if (key.size() != 1)
+        {
+            return false;
+        }
+
+        auto keyCode{ static_cast<uint8_t>(std::toupper(key.at(0))) };
+        if ((keyCode < 0x30) ||
+            (keyCode > 0x39 && keyCode < 0x41) ||
+            (keyCode > 0x5A))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    std::expected<std::unique_ptr<FlashCom::Models::ShellExecuteTreeNode>, std::string>
+        ParseToShellExecuteTreeNode(uint8_t keyCode, const std::string& name,
+            const nlohmann::json& json)
+    {
+        std::string executeFile;
+        std::string executeParameters;
+        if (!json.contains(c_commandExecuteFileJsonProperty) ||
+            !json.at(c_commandExecuteFileJsonProperty).is_string())
+        {
+            SPDLOG_ERROR("::ParseToShellExecuteTreeNode - Command '{}' type '{}' "
+                "has no valid '{}' string property", name, c_commandTypeValueShellExecute,
+                c_commandExecuteFileJsonProperty);
+            return std::unexpected(std::format(
+                "Command '{}' type '{}' has no valid '{}' string property",
+                name, c_commandTypeValueShellExecute, c_commandExecuteFileJsonProperty));
+        }
+        executeFile = json.at(c_commandExecuteFileJsonProperty).get<std::string>();
+
+        // executeParameters is optional
+        if (json.contains(c_commandExecuteParametersJsonProperty) &&
+            json.at(c_commandExecuteParametersJsonProperty).is_string())
+        {
+            executeParameters = json.at(c_commandExecuteParametersJsonProperty).get<std::string>();
+        }
+
+        SPDLOG_INFO("::ParseToShellExecuteTreeNode - Creating ShellExecute node {}:{}, "
+            "file: '{}', parameters: '{}'", static_cast<char>(keyCode), name,
+            executeFile, executeParameters);
+        return std::make_unique<FlashCom::Models::ShellExecuteTreeNode>(keyCode,
+            name, executeFile, executeParameters);
+    }
+
+    std::expected<std::unique_ptr<FlashCom::Models::LaunchUriTreeNode>, std::string>
+        ParseToLaunchUriTreeNode(uint8_t keyCode, const std::string& name,
+            const nlohmann::json& json)
+    {
+        if (!json.contains(c_commandUriJsonProperty) ||
+            !json.at(c_commandUriJsonProperty).is_string())
+        {
+            SPDLOG_ERROR("::ParseToLaunchUriTreeNode - Command '{}' type '{}' "
+                "has no valid '{}' string property", name, c_commandTypeValueUri,
+                c_commandUriJsonProperty);
+            return std::unexpected(std::format(
+                "Command '{}' type '{}' has no valid '{}' string property",
+                name, c_commandTypeValueUri, c_commandUriJsonProperty));
+        }
+        auto uri{ json.at(c_commandUriJsonProperty).get<std::string>() };
+        SPDLOG_INFO("::ParseToLaunchUriTreeNode - Creating LaunchUri node {}:{}, uri: '{}'",
+            static_cast<char>(keyCode), name, uri);
+        return std::make_unique<FlashCom::Models::LaunchUriTreeNode>(keyCode, name, uri);
+    }
+
+    std::expected<std::unique_ptr<FlashCom::Models::ActivateAumidTreeNode>, std::string>
+        ParseToActivateAumidTreeNode(uint8_t keyCode, const std::string& name,
+            const nlohmann::json& json)
+    {
+        if (!json.contains(c_commandAumidJsonProperty) ||
+            !json.at(c_commandAumidJsonProperty).is_string())
+        {
+            SPDLOG_ERROR("::ParseToActivateAumidTreeNode - Command '{}' type '{}' "
+                "has no valid '{}' string property", name, c_commandTypeValueAumid,
+                c_commandAumidJsonProperty);
+            return std::unexpected(std::format(
+                "Command '{}' type '{}' has no valid '{}' string property",
+                name, c_commandTypeValueAumid, c_commandAumidJsonProperty));
+        }
+        auto aumid{ json.at(c_commandAumidJsonProperty).get<std::string>() };
+        SPDLOG_INFO(
+            "::ParseToActivateAumidTreeNode - Creating ActivateAumid node {}:{}, aumid: '{}'",
+            static_cast<char>(keyCode), name, aumid);
+        return std::make_unique<FlashCom::Models::ActivateAumidTreeNode>(keyCode, name, aumid);
+    }
+
+    std::expected<std::unique_ptr<FlashCom::Models::TreeNode>, std::string> ParseToTreeNode(
+        const nlohmann::json& json)
     {
         std::vector<std::unique_ptr<FlashCom::Models::TreeNode>> nodeChildren;
 
-        // Basic validation
-        if (!json.contains("name") || !json.at("name").is_string() ||
-            !json.contains("key") || !json.at("key").is_string())
+        if (!json.contains(c_commandNameJsonProperty) ||
+            !json.at(c_commandNameJsonProperty).is_string() ||
+            !json.contains(c_commandKeyJsonProperty) ||
+            !json.at(c_commandKeyJsonProperty).is_string())
         {
-            // TODO: Log warning
-            return nullptr;
+            SPDLOG_ERROR("::ParseToTreeNode - no valid '{}' or '{}' string properties found",
+                c_commandNameJsonProperty, c_commandKeyJsonProperty);
+            return std::unexpected(std::format(
+                "Command object has no '{}' or '{}' string properties",
+                c_commandNameJsonProperty, c_commandKeyJsonProperty));
         }
 
-        auto nodeName{ json.at("name").get<std::string>() };
-        auto jsonKeyCodeString{ json.at("key").get<std::string>() };
-        uint32_t nodeKeyCode{ static_cast<uint32_t>(std::toupper(jsonKeyCodeString.at(0))) };
-        
-        if (json.contains("children") && json.at("children").is_array())
+        auto nodeName{ json.at(c_commandNameJsonProperty).get<std::string>() };
+        auto jsonKeyCodeString{ json.at(c_commandKeyJsonProperty).get<std::string>() };
+        if (!IsValidKeyString(jsonKeyCodeString))
         {
-            for (auto& childJson : json.at("children"))
+            SPDLOG_ERROR("::ParseToTreeNode - invalid '{}' value '{}', "
+                "must be single alphanumeric keyboard key", c_commandKeyJsonProperty,
+                jsonKeyCodeString);
+            return std::unexpected(std::format(
+                "Command object has invalid '{}' value '{}', "
+                "must be single alphanumeric keyboard key", c_commandKeyJsonProperty,
+                jsonKeyCodeString));
+        }
+        auto nodeKeyCode{ static_cast<uint8_t>(std::toupper(jsonKeyCodeString.at(0))) };
+
+        if (json.contains(c_commandChildrenJsonProperty))
+        {
+            if (!json.at(c_commandChildrenJsonProperty).is_array())
             {
-                if (auto childNode{ ParseToTreeNode(childJson) })
+                SPDLOG_ERROR("::ParseToTreeNode - '{}' must be an array of child commands",
+                    c_commandChildrenJsonProperty);
+                return std::unexpected(std::format(
+                    "Command object has invalid '{}' type, must be an array of child commands.",
+                    c_commandChildrenJsonProperty));
+            }
+
+            for (auto& childJson : json.at(c_commandChildrenJsonProperty))
+            {
+                auto childNode{ ParseToTreeNode(childJson) };
+                if (childNode.has_value())
                 {
-                    nodeChildren.push_back(std::move(childNode));
+                    nodeChildren.push_back(std::move(childNode.value()));
+                }
+                else
+                {
+                    SPDLOG_WARN("::ParseToTreeNode - Skipping child node of '{}': {}",
+                        nodeName, childNode.error());
                 }
             }
         }
 
-        if (json.contains("type") && json.at("type").is_string())
+        if (json.contains(c_commandTypeJsonProperty) &&
+            json.at(c_commandTypeJsonProperty).is_string())
         {
-            auto nodeType{ json.at("type").get<std::string>() };
-            if (nodeType == "shellExecute")
+            auto nodeType{ json.at(c_commandTypeJsonProperty).get<std::string>() };
+            if (json.contains(c_commandChildrenJsonProperty))
             {
-                std::string executeParameters;
-                auto executeFile{ json.at("executeFile").get<std::string>() };
-                if (json.contains("executeParameters") && json.at("executeParameters").is_string())
-                {
-                    executeParameters = json.at("executeParameters").get<std::string>();
-                }
-                return std::make_unique<FlashCom::Models::ShellExecuteTreeNode>(nodeKeyCode,
-                    nodeName, executeFile, executeParameters);
+                SPDLOG_WARN("::ParseToTreeNode - Command '{}' contains both '{}' and '{}' "
+                    "properties. Skipping '{}'...", nodeName, c_commandChildrenJsonProperty,
+                    c_commandTypeJsonProperty, c_commandTypeJsonProperty);
             }
-            else if (nodeType == "uri")
+            else if (nodeType == c_commandTypeValueShellExecute)
             {
-                auto uri{ json.at("uri").get<std::string>() };
-                return std::make_unique<FlashCom::Models::LaunchUriTreeNode>(nodeKeyCode,
-                    nodeName, uri);
+                return ParseToShellExecuteTreeNode(nodeKeyCode, nodeName, json);
             }
-            else if (nodeType == "aumid")
+            else if (nodeType == c_commandTypeValueUri)
             {
-                auto aumid{ json.at("aumid").get<std::string>() };
-                return std::make_unique<FlashCom::Models::ActivateAumidTreeNode>(nodeKeyCode,
-                    nodeName, aumid);
+                return ParseToLaunchUriTreeNode(nodeKeyCode, nodeName, json);
+            }
+            else if (nodeType == c_commandTypeValueAumid)
+            {
+                return ParseToActivateAumidTreeNode(nodeKeyCode, nodeName, json);
             }
             else
             {
-                // TODO: LOG ERROR
+                SPDLOG_ERROR(
+                    "::ParseToTreeNode - Command '{}' contains an unknown '{}' value '{}'",
+                    nodeName, c_commandTypeJsonProperty, nodeType);
+                return std::unexpected(std::format(
+                    "Command '{}' contains an unknown '{}' value '{}'",
+                    nodeName, c_commandTypeJsonProperty, nodeType));
             }
         }
 
+        SPDLOG_INFO("::ParseToTreeNode - Creating node {}:{} with {} children",
+            static_cast<char>(nodeKeyCode), nodeName, nodeChildren.size());
         return std::make_unique<FlashCom::Models::TreeNode>(nodeKeyCode, nodeName,
             std::move(nodeChildren));
     }
@@ -138,31 +280,77 @@ namespace FlashCom::Settings
         }
     }
 
+    std::expected<void, std::string> SettingsManager::LoadSettings()
+    {
+        SPDLOG_INFO("SettingsManager::LoadSettings - Loading settings from {}...",
+            m_settingsFilePath.string());
+        std::unique_lock settingsLock{ m_settingsAccessMutex };
+        std::ifstream settingsFileStream{};
+        nlohmann::json settingsJson{};
+        try
+        {
+            settingsFileStream = std::ifstream{ m_settingsFilePath };
+            settingsJson = nlohmann::json::parse(settingsFileStream);
+        }
+        catch (const nlohmann::json::exception& e)
+        {
+            SPDLOG_ERROR("SettingsManager::LoadSettings - Could not parse settings.json file: {}",
+                e.what());
+            return std::unexpected(std::format("Could not parse settings.json file: {}",
+                e.what()));
+        }
+
+        PopulateCommandTree(settingsLock, settingsJson);
+        return {}; // Spurious warning C4715
+    }
+
     std::filesystem::path SettingsManager::GetSettingsFilePath()
     {
+        std::shared_lock settingsLock{ m_settingsAccessMutex };
         return m_settingsFilePath;
     }
 
-    std::unique_ptr<Models::TreeNode> SettingsManager::GetTree()
+    std::shared_ptr<Models::TreeNode> SettingsManager::GetCommandTreeRoot()
     {
-        std::vector<std::unique_ptr<Models::TreeNode>> rootChildren;
-        std::ifstream settingsFileStream{ m_settingsFilePath };
-        const auto settingsJson{ nlohmann::json::parse(settingsFileStream) };
-        if (settingsJson.contains("commandTree"))
+        std::shared_lock settingsLock{ m_settingsAccessMutex };
+        return m_commandTreeRoot;
+    }
+
+    std::expected<void, std::string> SettingsManager::PopulateCommandTree(
+        const std::unique_lock<std::shared_mutex>& /*accessLock*/,
+        const nlohmann::json& settingsJson)
+    {
+        SPDLOG_INFO("SettingsManager::PopulateCommandTree");
+        m_commandTreeRoot = nullptr;
+
+        if (!settingsJson.contains(c_commandsJsonProperty) ||
+            !settingsJson.at(c_commandsJsonProperty).is_array())
         {
-            const auto& commandTreeJson{ settingsJson.at("commandTree") };
-            commandTreeJson.is_array();
-            for (const auto& commandTreeObject : commandTreeJson)
-            {
-                auto treeNode{ ParseToTreeNode(commandTreeObject) };
-                rootChildren.push_back(std::move(treeNode));
-            }
-        }
-        else
-        {
-            // Log error
+            SPDLOG_ERROR("SettingsManager::PopulateCommandTree - No '{}' array property found",
+                c_commandsJsonProperty);
+            return std::unexpected(std::format("No '{}' array property found.",
+                c_commandsJsonProperty));
         }
 
-        return std::make_unique<Models::TreeNode>(0, "Root", std::move(rootChildren));
+        std::vector<std::unique_ptr<Models::TreeNode>> rootChildren;
+        const auto& commandTreeJson{ settingsJson.at(c_commandsJsonProperty) };
+        for (const auto& commandTreeObject : commandTreeJson)
+        {
+            auto rootChild{ ParseToTreeNode(commandTreeObject) };
+            if (rootChild.has_value())
+            {
+                rootChildren.push_back(std::move(rootChild.value()));
+            }
+            else
+            {
+                SPDLOG_WARN("SettingsManager::PopulateCommandTree - Skipping root child: {}",
+                    rootChild.error());
+            }
+        }
+
+        SPDLOG_INFO("SettingsManager::PopulateCommandTree - Creating root node with {} children",
+            rootChildren.size());
+        m_commandTreeRoot = std::make_shared<Models::TreeNode>(0, "Root", std::move(rootChildren));
+        return {}; // Spurious warning C4715
     }
 }

--- a/src/FlashCom/Settings/SettingsManager.h
+++ b/src/FlashCom/Settings/SettingsManager.h
@@ -1,5 +1,7 @@
 #pragma once
+#include <expected>
 #include <filesystem>
+#include <shared_mutex>
 #include "../Models/TreeNode.h"
 
 namespace FlashCom::Settings
@@ -7,10 +9,17 @@ namespace FlashCom::Settings
     struct SettingsManager
     {
         SettingsManager();
+        std::expected<void, std::string> LoadSettings();
         std::filesystem::path GetSettingsFilePath();
-        std::unique_ptr<Models::TreeNode> GetTree();
+        std::shared_ptr<Models::TreeNode> GetCommandTreeRoot();
 
     private:
         std::filesystem::path const m_settingsFilePath;
+        std::shared_mutex m_settingsAccessMutex;
+        std::shared_ptr<Models::TreeNode> m_commandTreeRoot;
+
+        std::expected<void, std::string> PopulateCommandTree(
+            const std::unique_lock<std::shared_mutex>& accessLock,
+            const nlohmann::json& settingsJson);
     };
 }


### PR DESCRIPTION
This change makes settings parsing more resilient to errors and adds a "reload" option to the system tray menu to allow for loading settings changes without restarting the process.