### PR TITLE
✖️ Escape key hides

### DIFF
--- a/src/FlashCom/App.cpp
+++ b/src/FlashCom/App.cpp
@@ -148,6 +148,12 @@ namespace FlashCom
 
     void App::OnKeyDown(uint8_t vkeyCode)
     {
+        if (vkeyCode == VK_ESCAPE)
+        {
+            SPDLOG_INFO("App::OnKeyDown - Escape key pressed; hiding");
+            Hide();
+            return;
+        }
         for (const auto& childNode : m_dataModel->CurrentNode->GetChildren())
         {
             if (childNode->GetVkCode() == vkeyCode)


### PR DESCRIPTION
Pressing the escape key while FlashCom is in focus will hide/close FlashCom.