### PR TITLE
📏 Add 'high DPI aware' to application manifest

### DIFF
--- a/src/FlashCom/FlashCom.vcxproj
+++ b/src/FlashCom/FlashCom.vcxproj
@@ -55,6 +55,9 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>windowsapp.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <Manifest>
+      <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
+    </Manifest>
   </ItemDefinitionGroup>
   <!-- /GLOBAL -->
   <!-- Solution-wide properties -->


### PR DESCRIPTION
Addresses #8.

Windows Store Certification tools show a warning if this value isn't set, so let's set it.