### PR TITLE
🎁 Add support for running FlashCom unpackaged

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: FlashCom_AppPackage
-          path: src/Packaging/AppPackages/Packaging_*/**/*
+          path: |
+            src/Packaging/AppPackages/Packaging_*/**
       - name: Upload x64 Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -34,7 +35,7 @@ jobs:
       - name: Upload ARM64 Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: FlashCom_x64
+          name: FlashCom_ARM64
           path: |
             build/bin/ARM64/Release/FlashCom/*
             !build/bin/ARM64/Release/FlashCom/*.pdb

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
           name: FlashCom_AppPackage
           path: |
             src/Packaging/AppPackages/**/*
-            !*.msixupload
+            !src/Packaging/AppPackages/*.msixupload
       - name: Upload x64 Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,8 @@ jobs:
         with:
           name: FlashCom_AppPackage
           path: |
-            src/Packaging/AppPackages/Packaging_*/**
+            src/Packaging/AppPackages/**/*
+            !*.msixupload
       - name: Upload x64 Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,22 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
       - name: Build
         run: msbuild FlashCom.sln /p:ProjectName="FlashCom" /p:Configuration="Release" /p:Platform="x64" /p:AppxBundle="Always" /p:AppxPackageSigningEnabled=true /p:PackageCertificateThumbprint="feedcf964fdcb3e04e4b27f86536cb269e40f873" /p:PackageCertificateKeyFile="Packaging_TemporaryKey.pfx" /p:UapAppxPackageBuildMode="Sideload" /p:AppxBundlePlatforms="x64|ARM64" /p:AppxPackageDir="AppPackages"
-      - name: Upload Artifact
+      - name: Upload App Package Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: AppPackage
-          path: src/Packaging/AppPackages
+          name: FlashCom_AppPackage
+          path: src/Packaging/AppPackages/Packaging_*/**/*
+      - name: Upload x64 Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: FlashCom_x64
+          path: |
+            build/bin/x64/Release/FlashCom/*
+            !build/bin/x64/Release/FlashCom/*.pdb
+      - name: Upload ARM64 Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: FlashCom_x64
+          path: |
+            build/bin/ARM64/Release/FlashCom/*
+            !build/bin/ARM64/Release/FlashCom/*.pdb

--- a/src/FlashCom/FlashCom.vcxproj
+++ b/src/FlashCom/FlashCom.vcxproj
@@ -152,6 +152,7 @@
     <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.220131.2\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220131.2\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="..\..\packages\Microsoft.VCRTForwarders.140.1.0.7\build\native\Microsoft.VCRTForwarders.140.targets" Condition="Exists('..\..\packages\Microsoft.VCRTForwarders.140.1.0.7\build\native\Microsoft.VCRTForwarders.140.targets')" />
     <Import Project="..\..\packages\Win2D.uwp.1.26.0\build\native\Win2D.uwp.targets" Condition="Exists('..\..\packages\Win2D.uwp.1.26.0\build\native\Win2D.uwp.targets')" />
+    <Import Project="..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -161,6 +162,7 @@
     <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220131.2\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.220131.2\build\native\Microsoft.Windows.CppWinRT.targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.VCRTForwarders.140.1.0.7\build\native\Microsoft.VCRTForwarders.140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VCRTForwarders.140.1.0.7\build\native\Microsoft.VCRTForwarders.140.targets'))" />
     <Error Condition="!Exists('..\..\packages\Win2D.uwp.1.26.0\build\native\Win2D.uwp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Win2D.uwp.1.26.0\build\native\Win2D.uwp.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
   <!-- /Packages -->
 </Project>

--- a/src/FlashCom/Settings/SettingsManager.h
+++ b/src/FlashCom/Settings/SettingsManager.h
@@ -6,6 +6,8 @@
 
 namespace FlashCom::Settings
 {
+    std::filesystem::path GetApplicationLocalDataDirectory();
+
     struct SettingsManager
     {
         SettingsManager();

--- a/src/FlashCom/main.cpp
+++ b/src/FlashCom/main.cpp
@@ -32,9 +32,7 @@ namespace
     int Run(HINSTANCE hInstance)
     {
         winrt::init_apartment(winrt::apartment_type::single_threaded);
-        auto logFilePath{
-            std::filesystem::path{ winrt::WStorage::ApplicationData::Current()
-                .LocalFolder().Path().c_str() } / c_logFileName };
+        auto logFilePath{ FlashCom::Settings::GetApplicationLocalDataDirectory() / c_logFileName };
         InitializeLogging(logFilePath.string());
         g_app = FlashCom::App::CreateApp(hInstance);
         FlashCom::Input::SetGlobalLowLevelKeyboardCallback(HandleLowLevelKeyboardInput);

--- a/src/FlashCom/packages.config
+++ b/src/FlashCom/packages.config
@@ -2,5 +2,6 @@
 <packages>
   <package id="Microsoft.VCRTForwarders.140" version="1.0.7" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.220131.2" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240122.1" targetFramework="native" />
   <package id="Win2D.uwp" version="1.26.0" targetFramework="native" />
 </packages>

--- a/src/FlashCom/pch.h
+++ b/src/FlashCom/pch.h
@@ -23,6 +23,9 @@
 #include <windows.ui.composition.interop.h>
 #include <winrt/Windows.UI.Text.h>
 
+// WIL
+#include <wil/resource.h>
+
 // Logging
 #include "Logging.h"
 

--- a/src/Packaging/Packaging.wapproj
+++ b/src/Packaging/Packaging.wapproj
@@ -77,7 +77,6 @@
     <Content Include="Images\StoreLogo.scale-200.png" />
     <Content Include="Images\StoreLogo.scale-400.png" />
     <None Include="Packaging_TemporaryKey.pfx" />
-    <None Include="Package.StoreAssociation.xml" />
   </ItemGroup>
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />
   <ItemGroup>


### PR DESCRIPTION
Resolves #18 

Removes dependency on APIs that require "package identity" so FlashCom can run both inside of an app package and as a standalone process.