### PR TITLE
📂 Fix ShellExecute to properly determine working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,7 @@ parameters.
             "name": "Calculator",
             "key": "C",
             "type": "shellExecute",
-            "executeFile": "calc.exe",
-            "executeParameters": ""
+            "executeFile": "calc.exe"
         },
         {
             "name": "Spotify Web",
@@ -116,11 +115,19 @@ parameters.
             "executeParameters": "--app=\"https://open.spotify.com\""
         },
         {
-            "name": "Absolute Path",
+            "name": "C Drive",
             "key": "A",
             "type": "shellExecute",
             "executeFile": "C:\\Windows\\explorer.exe",
-            "executeParameters": ""
+            "executeParameters": "C:\"
+        },
+        {
+            "name": "VS Code",
+            "key": "A",
+            "type": "shellExecute",
+            "executeFile": "C:\\Users\\Hayden\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe",
+            "executeParameters": "",
+            "executeDirectory": "C:\\Users\\Hayden\\AppData\\Local\\Programs\\Microsoft VS Code"
         }
     ]
 }

--- a/src/FlashCom/Models/ShellExecuteTreeNode.cpp
+++ b/src/FlashCom/Models/ShellExecuteTreeNode.cpp
@@ -1,11 +1,38 @@
 #include <pch.h>
 #include "ShellExecuteTreeNode.h"
 
+namespace
+{
+    std::optional<std::filesystem::path> GetExecuteDirectory(std::string_view file,
+        std::string_view directory)
+    {
+        if (directory.length() > 0)
+        {
+            return directory;
+        }
+
+        // Default to the folder containing the file if one exists
+        std::filesystem::path filePath{ file };
+        if (filePath.has_parent_path())
+        {
+            auto parentPath{ filePath.parent_path() };
+            SPDLOG_INFO("::GetExecuteDirectory - No execute directory defined for '{}', "
+                "defaulting to '{}'", file, parentPath.string());
+            return parentPath;
+        }
+
+        SPDLOG_INFO("::GetExecuteDirectory - No execute directory defined for '{}', "
+            "defaulting to null.", file);
+        return std::nullopt;
+    }
+}
+
 namespace FlashCom::Models
 {
     ShellExecuteTreeNode::ShellExecuteTreeNode(uint32_t vkCode, std::string_view name,
-        std::string_view file, std::string_view parameters) : TreeNode{ vkCode, name, {} },
-        m_file{ file }, m_parameters{ parameters }
+        std::string_view file, std::string_view parameters, std::string_view directory) :
+        TreeNode{ vkCode, name, {} }, m_file{ file }, m_parameters{ parameters },
+        m_directory{ GetExecuteDirectory(file, directory) }
     { }
     void ShellExecuteTreeNode::Execute() const
     {
@@ -16,7 +43,8 @@ namespace FlashCom::Models
             L"open",
             reinterpret_cast<wchar_t*>(fileString.data()),
             reinterpret_cast<wchar_t*>(parametersString.data()),
-            nullptr,
+            m_directory.has_value() ?
+                reinterpret_cast<wchar_t*>(m_directory.value().wstring().data()) : nullptr,
             SW_SHOWNORMAL
         ) };
         if (reinterpret_cast<INT_PTR>(executeResult) <= 32)

--- a/src/FlashCom/Models/ShellExecuteTreeNode.h
+++ b/src/FlashCom/Models/ShellExecuteTreeNode.h
@@ -6,10 +6,11 @@ namespace FlashCom::Models
 struct ShellExecuteTreeNode : public TreeNode
 {
     ShellExecuteTreeNode(uint32_t vkCode, std::string_view name, std::string_view file,
-        std::string_view parameters);
+        std::string_view parameters, std::string_view directory);
     void Execute() const override;
 private:
     const std::string m_file;
     const std::string m_parameters;
+    const std::optional<std::filesystem::path> m_directory;
 };
 }

--- a/src/FlashCom/Settings/SettingsManager.cpp
+++ b/src/FlashCom/Settings/SettingsManager.cpp
@@ -20,6 +20,7 @@ namespace
     constexpr std::string_view c_commandTypeJsonProperty{ "type" };
     constexpr std::string_view c_commandExecuteFileJsonProperty{ "executeFile" };
     constexpr std::string_view c_commandExecuteParametersJsonProperty{ "executeParameters" };
+    constexpr std::string_view c_commandExecuteDirectoryJsonProperty{ "executeDirectory" };
     constexpr std::string_view c_commandUriJsonProperty{ "uri" };
     constexpr std::string_view c_commandAumidJsonProperty{ "aumid" };
     // JSON command node 'type' values
@@ -44,14 +45,16 @@ namespace
                     "key": "C",
                     "type": "shellExecute",
                     "executeFile": "calc.exe",
-                    "executeParameters": ""
+                    "executeParameters": "",
+                    "executeDirectory": ""
                 },
                 {
                     "name": "Notepad",
                     "key": "N",
                     "type": "shellExecute",
                     "executeFile": "notepad.exe",
-                    "executeParameters": ""
+                    "executeParameters": "",
+                    "executeDirectory": ""
                 },
                 {
                     "name": "Settings",
@@ -66,7 +69,8 @@ namespace
             "key": "E",
             "type": "shellExecute",
             "executeFile": "msedge.exe",
-            "executeParameters": ""
+            "executeParameters": "",
+            "executeDirectory": ""
         }
     ]
 })" };
@@ -103,6 +107,7 @@ namespace
     {
         std::string executeFile;
         std::string executeParameters;
+        std::string executeDirectory;
         if (!json.contains(c_commandExecuteFileJsonProperty) ||
             !json.at(c_commandExecuteFileJsonProperty).is_string())
         {
@@ -122,11 +127,18 @@ namespace
             executeParameters = json.at(c_commandExecuteParametersJsonProperty).get<std::string>();
         }
 
+        // executeDirectory is optional
+        if (json.contains(c_commandExecuteDirectoryJsonProperty) &&
+            json.at(c_commandExecuteDirectoryJsonProperty).is_string())
+        {
+            executeDirectory = json.at(c_commandExecuteDirectoryJsonProperty).get<std::string>();
+        }
+
         SPDLOG_INFO("::ParseToShellExecuteTreeNode - Creating ShellExecute node {}:{}, "
-            "file: '{}', parameters: '{}'", static_cast<char>(keyCode), name,
-            executeFile, executeParameters);
+            "file: '{}', parameters: '{}', directory: '{}'", static_cast<char>(keyCode), name,
+            executeFile, executeParameters, executeDirectory);
         return std::make_unique<FlashCom::Models::ShellExecuteTreeNode>(keyCode,
-            name, executeFile, executeParameters);
+            name, executeFile, executeParameters, executeDirectory);
     }
 
     std::expected<std::unique_ptr<FlashCom::Models::LaunchUriTreeNode>, std::string>


### PR DESCRIPTION
ShellExecute commands would previously always pass a null starting directory to the [ShellExecuteW](https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shellexecutew) function, resulting in applications getting launched in FlashCom's working directory, breaking apps that load binaries or other resources from their directory on disk.

This change introduces a new optional JSON property `"executeDirectory"` that allows a user to specify a starting directory.

If a starting directory is not provided, the specified file path is used to determine the working directory. If the path does not provide a parent directory, then a null value is passed to `ShellExecuteW`.