### PR TITLE
🐛 Add hotkey reset logic to avoid stuck keys

### DIFF
--- a/src/FlashCom/App.h
+++ b/src/FlashCom/App.h
@@ -28,10 +28,12 @@ namespace FlashCom
         View::TrayIcon m_trayIcon;
         View::Ui m_ui;
         std::unordered_set<uint32_t> m_hotkeysPressed;
+        winrt::Windows::System::Threading::ThreadPoolTimer m_hotkeyResetTimer{ nullptr };
         bool m_isShowing{ false };
 
         App(const HINSTANCE& hInstance);
         void HandleFocusLost();
+        void OnHotkeyTimerElapsed(winrt::Windows::System::Threading::ThreadPoolTimer timer);
         void OnKeyDown(uint8_t vkeyCode);
         void OnKeyUp(uint8_t vkeyCode);
         void Show();

--- a/src/FlashCom/pch.h
+++ b/src/FlashCom/pch.h
@@ -18,6 +18,7 @@
 #include <winrt/Windows.Graphics.Effects.h>
 #include <winrt/Windows.Storage.h>
 #include <winrt/Windows.System.h>
+#include <winrt/Windows.System.Threading.h>
 #include <winrt/Windows.UI.Composition.h>
 #include <winrt/Windows.UI.Composition.Desktop.h>
 #include <windows.ui.composition.interop.h>
@@ -52,6 +53,7 @@ namespace winrt
     namespace WGDX = Windows::Graphics::DirectX;
     namespace WStorage = Windows::Storage;
     namespace WS = Windows::System;
+    namespace WST = Windows::System::Threading;
     namespace WUI = Windows::UI;
     namespace WUIC = Windows::UI::Composition;
     namespace WUICD = Windows::UI::Composition::Desktop;

--- a/src/Packaging/Package.appxmanifest
+++ b/src/Packaging/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="164HaydenMcAfee.FlashCom"
     Publisher="CN=5061D826-8E2A-4755-932E-A6DD607C027B"
-    Version="0.2.0.0" />
+    Version="0.2.1.0" />
 
   <Properties>
     <DisplayName>FlashCom</DisplayName>


### PR DESCRIPTION
Occasionally, the hotkey management logic would get "stuck" thinking a key is pressed when it isn't.

This can happen if keyboard events are prevented from reaching the FlashCom process for a variety of reasons (ex. if the user invokes the lock screen with Win+L, the key-up event for the Win key will not reach FlashCom).

This change adds a hotkey reset timer that resets all hotkey state after 1 second of inactivity. The timer is reset each time a new hotkey key is pressed. This will prevent FlashCom from maintaining a bad keyboard state, even if keyboard events are interrupted.

This change also bumps the version to 0.2.1.