### PR TITLE
🍞 Show toast notification on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ For the packaged app, `settings.json` is located in `%LOCALAPPDATA%\Packages\164
 
 For the unpackaged app, `settings.json` is located in `%LOCALAPPDATA%\FlashCom`.
 
+The following fields can be set in the `settings.json` root object:
+
+| Name                        | Type                     | Description                                |
+| --------------------------- | ------------------------ | ------------------------------------------ |
+| `"showStartupNotification"` | `true` / `false`         | Determines whether the "FlashCom is running" toast notification is shown on startup. |
+| `"commands"`                | Array of Command Objects | The set of commands shown in FlashCom.     |
+
 ## Commands
 
 | Name         | "type"           | Description                                |

--- a/src/FlashCom/Models/DataModel.h
+++ b/src/FlashCom/Models/DataModel.h
@@ -6,6 +6,7 @@ namespace FlashCom::Models
     struct DataModel
     {
         std::string LoadErrorMessage;
+        bool ShowStartupNotification;
         std::shared_ptr<TreeNode> RootNode;
         TreeNode* CurrentNode{ nullptr };
     };

--- a/src/FlashCom/Settings/SettingsManager.h
+++ b/src/FlashCom/Settings/SettingsManager.h
@@ -13,13 +13,18 @@ namespace FlashCom::Settings
         SettingsManager();
         std::expected<void, std::string> LoadSettings();
         std::filesystem::path GetSettingsFilePath();
+        bool GetShowStartupNotification();
         std::shared_ptr<Models::TreeNode> GetCommandTreeRoot();
 
     private:
         std::filesystem::path const m_settingsFilePath;
         std::shared_mutex m_settingsAccessMutex;
+        bool m_showStartupNotification{ true };
         std::shared_ptr<Models::TreeNode> m_commandTreeRoot;
 
+        void PopulateSettingsValues(
+            const std::unique_lock<std::shared_mutex>& accessLock,
+            const nlohmann::json& settingsJson);
         std::expected<void, std::string> PopulateCommandTree(
             const std::unique_lock<std::shared_mutex>& accessLock,
             const nlohmann::json& settingsJson);

--- a/src/FlashCom/main.cpp
+++ b/src/FlashCom/main.cpp
@@ -40,22 +40,18 @@ namespace
     }
 }
 
-// Console entrypoint
-int main(
-    int /*argc*/,
-    wchar_t* /*argv*/[]
-)
-{
-    return Run(GetModuleHandleW(nullptr));
-}
-
 // Windows entrypoint
 int WINAPI wWinMain(
     HINSTANCE hInstance,
     HINSTANCE /*hPrevInstance*/,
-    LPWSTR /*lpCmdLine*/,
+    LPWSTR lpCmdLine,
     int /*nCmdShow*/
 )
 {
+    // Ignore launches that were triggered from the startup notification toast
+    if ((std::wstring{ L"-from-startup-toast" }.compare(lpCmdLine) == 0))
+    {
+        return 0;
+    }
     return Run(hInstance);
 }

--- a/src/FlashCom/pch.h
+++ b/src/FlashCom/pch.h
@@ -13,6 +13,7 @@
 #include <winrt/Microsoft.Graphics.Canvas.Geometry.h>
 #include <winrt/Microsoft.Graphics.Canvas.Text.h>
 #include <winrt/Microsoft.Graphics.Canvas.UI.Composition.h>
+#include <winrt/Windows.Data.Xml.Dom.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Graphics.DirectX.h>
 #include <winrt/Windows.Graphics.Effects.h>
@@ -22,6 +23,7 @@
 #include <winrt/Windows.UI.Composition.h>
 #include <winrt/Windows.UI.Composition.Desktop.h>
 #include <windows.ui.composition.interop.h>
+#include <winrt/Windows.UI.Notifications.h>
 #include <winrt/Windows.UI.Text.h>
 
 // WIL
@@ -49,6 +51,7 @@ namespace winrt
     namespace MGCG = Microsoft::Graphics::Canvas::Geometry;
     namespace MGCT = Microsoft::Graphics::Canvas::Text;
     namespace MGCUC = Microsoft::Graphics::Canvas::UI::Composition;
+    namespace WDXD = Windows::Data::Xml::Dom;
     namespace WF = Windows::Foundation;
     namespace WGDX = Windows::Graphics::DirectX;
     namespace WStorage = Windows::Storage;
@@ -57,5 +60,6 @@ namespace winrt
     namespace WUI = Windows::UI;
     namespace WUIC = Windows::UI::Composition;
     namespace WUICD = Windows::UI::Composition::Desktop;
+    namespace WUIN = Windows::UI::Notifications;
     namespace WUIT = Windows::UI::Text;
 }


### PR DESCRIPTION
The most recent FlashCom update failed Windows Store certification because there was no clear indication that the application had launched successfully.

This change adds a toast notification that triggers on startup to tell the user that the app is running, and how to invoke it.

It can be disabled by setting `"showStartupNotification"` to `false` in `settings.json`.