### PR TITLE
🕝 Simple date/time visual added

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The following fields can be set in the `settings.json` root object:
 | Name                        | Type                     | Description                                |
 | --------------------------- | ------------------------ | ------------------------------------------ |
 | `"showStartupNotification"` | `true` / `false`         | Determines whether the "FlashCom is running" toast notification is shown on startup. |
+| `"use24HourClock"`          | `true` / `false`         | Determines whether a 12-hour or 24-hour clock is shown. |
 | `"commands"`                | Array of Command Objects | The set of commands shown in FlashCom.     |
 
 ## Commands

--- a/src/FlashCom/App.cpp
+++ b/src/FlashCom/App.cpp
@@ -45,6 +45,7 @@ namespace FlashCom
     {
         auto result{ m_settingsManager.LoadSettings() };
         m_dataModel->ShowStartupNotification = m_settingsManager.GetShowStartupNotification();
+        m_dataModel->UseTwentyFourHourClock = m_settingsManager.UseTwentyFourHourClock();
         m_dataModel->RootNode = m_settingsManager.GetCommandTreeRoot();
         m_dataModel->CurrentNode = m_dataModel->RootNode.get();
         if (!result.has_value())

--- a/src/FlashCom/Models/DataModel.h
+++ b/src/FlashCom/Models/DataModel.h
@@ -7,6 +7,7 @@ namespace FlashCom::Models
     {
         std::string LoadErrorMessage;
         bool ShowStartupNotification;
+        bool UseTwentyFourHourClock;
         std::shared_ptr<TreeNode> RootNode;
         TreeNode* CurrentNode{ nullptr };
     };

--- a/src/FlashCom/Settings/SettingsManager.cpp
+++ b/src/FlashCom/Settings/SettingsManager.cpp
@@ -14,6 +14,7 @@ namespace
     constexpr std::string_view c_settingsFileName{ "settings.json" };
     // JSON property names
     constexpr std::string_view c_showStartupNotificationProperty{ "showStartupNotification" };
+    constexpr std::string_view c_useTwentyFourHourClockProperty{ "use24HourClock" };
     constexpr std::string_view c_commandsJsonProperty{ "commands" };
     constexpr std::string_view c_commandNameJsonProperty{ "name" };
     constexpr std::string_view c_commandKeyJsonProperty{ "key" };
@@ -31,6 +32,7 @@ namespace
     // Default settings.json contents
     constexpr std::string_view c_defaultSettingsFileContents{ R"({
     "showStartupNotification": true,
+    "use24HourClock": true,
     "commands": [
         {
             "name": "README",
@@ -369,6 +371,11 @@ namespace FlashCom::Settings
         return m_showStartupNotification;
     }
 
+    bool SettingsManager::UseTwentyFourHourClock()
+    {
+        return m_useTwentyFourHourClock;
+    }
+
     std::shared_ptr<Models::TreeNode> SettingsManager::GetCommandTreeRoot()
     {
         std::shared_lock settingsLock{ m_settingsAccessMutex };
@@ -392,6 +399,19 @@ namespace FlashCom::Settings
             SPDLOG_INFO("SettingsManager::PopulateSettingsValues - No '{}' bool property found. "
                 "Defaulting to '{}'.", c_showStartupNotificationProperty,
                 m_showStartupNotification);
+        }
+
+        if (settingsJson.contains(c_useTwentyFourHourClockProperty) &&
+            settingsJson.at(c_useTwentyFourHourClockProperty).is_boolean())
+        {
+            m_useTwentyFourHourClock =
+                settingsJson.at(c_useTwentyFourHourClockProperty).get<bool>();
+        }
+        else
+        {
+            SPDLOG_INFO("SettingsManager::PopulateSettingsValues - No '{}' bool property found. "
+                "Defaulting to '{}'.", c_useTwentyFourHourClockProperty,
+                m_useTwentyFourHourClock);
         }
     }
 

--- a/src/FlashCom/Settings/SettingsManager.cpp
+++ b/src/FlashCom/Settings/SettingsManager.cpp
@@ -32,7 +32,7 @@ namespace
     // Default settings.json contents
     constexpr std::string_view c_defaultSettingsFileContents{ R"({
     "showStartupNotification": true,
-    "use24HourClock": true,
+    "use24HourClock": false,
     "commands": [
         {
             "name": "README",

--- a/src/FlashCom/Settings/SettingsManager.h
+++ b/src/FlashCom/Settings/SettingsManager.h
@@ -14,12 +14,14 @@ namespace FlashCom::Settings
         std::expected<void, std::string> LoadSettings();
         std::filesystem::path GetSettingsFilePath();
         bool GetShowStartupNotification();
+        bool UseTwentyFourHourClock();
         std::shared_ptr<Models::TreeNode> GetCommandTreeRoot();
 
     private:
         std::filesystem::path const m_settingsFilePath;
         std::shared_mutex m_settingsAccessMutex;
         bool m_showStartupNotification{ true };
+        bool m_useTwentyFourHourClock{ true };
         std::shared_ptr<Models::TreeNode> m_commandTreeRoot;
 
         void PopulateSettingsValues(

--- a/src/FlashCom/Settings/SettingsManager.h
+++ b/src/FlashCom/Settings/SettingsManager.h
@@ -21,7 +21,7 @@ namespace FlashCom::Settings
         std::filesystem::path const m_settingsFilePath;
         std::shared_mutex m_settingsAccessMutex;
         bool m_showStartupNotification{ true };
-        bool m_useTwentyFourHourClock{ true };
+        bool m_useTwentyFourHourClock{ false };
         std::shared_ptr<Models::TreeNode> m_commandTreeRoot;
 
         void PopulateSettingsValues(

--- a/src/FlashCom/View/Ui.cpp
+++ b/src/FlashCom/View/Ui.cpp
@@ -121,6 +121,17 @@ namespace
 
         return spriteVisual;
     }
+
+    std::chrono::milliseconds TimeToNextMinute()
+    {
+        auto const time = std::chrono::current_zone()
+            ->to_local(std::chrono::system_clock::now());
+        auto minutes = std::chrono::floor<std::chrono::minutes>(time);
+        auto ms = std::chrono::floor<std::chrono::milliseconds>(time);
+        auto untilNextMinute = std::chrono::floor<std::chrono::milliseconds>(
+            std::chrono::minutes{ 1 } - (ms - minutes));
+        return untilNextMinute;
+    }
 }
 
 namespace FlashCom::View
@@ -159,6 +170,12 @@ namespace FlashCom::View
     void Ui::Hide()
     {
         m_hostWindow.Hide();
+        if (m_clockUpdateTimer)
+        {
+            SPDLOG_INFO("Ui::Hide - Canceling clock timer");
+            m_clockUpdateTimer.Cancel();
+            m_clockUpdateTimer = nullptr;
+        }
     }
 
     void Ui::Update(UpdateReasonKind reason)
@@ -223,6 +240,16 @@ namespace FlashCom::View
             m_backgroundVisual.StartAnimation(L"opacity", m_backgroundFadeInAnimation);
             m_contentsVisual.StartAnimation(L"opacity", m_backgroundFadeInAnimation);
             m_contentsVisual.StartAnimation(L"scale", m_contentScaleInAnimation);
+
+            if (m_clockUpdateTimer)
+            {
+                m_clockUpdateTimer.Cancel();
+                m_clockUpdateTimer = nullptr;
+            }
+            auto nextUpdate{ TimeToNextMinute() };
+            SPDLOG_INFO("Ui::Update - setting clock timer for {}ms", nextUpdate.count());
+            m_clockUpdateTimer = winrt::WST::ThreadPoolTimer::CreateTimer(
+                { this, &Ui::OnClockUpdateTimerElapsed }, nextUpdate);
         }
     }
 
@@ -231,15 +258,19 @@ namespace FlashCom::View
         static auto const locale{ std::locale("") };
         auto const time = std::chrono::current_zone()
             ->to_local(std::chrono::system_clock::now());
-
+        auto days = std::chrono::floor<std::chrono::days>(time);
+        std::chrono::hh_mm_ss hhmmss{ std::chrono::floor<std::chrono::milliseconds>(time - days) };
         std::string timeText;
+
         if (m_dataModel->UseTwentyFourHourClock)
         {
-            timeText = std::format(locale, "{0:%H}:{0:%M}", time);
+            timeText = std::format(locale, "{:0>2}:{:0>2}", hhmmss.hours().count(),
+                hhmmss.minutes().count());
         }
         else
         {
-            timeText = std::format(locale, "{0:%I}:{0:%M}", time);
+            timeText = std::format(locale, "{}:{:0>2}", hhmmss.hours().count() % 12,
+                hhmmss.minutes().count());
         }
 
         winrt::MGCT::CanvasTextFormat timeTextFormat;
@@ -248,26 +279,41 @@ namespace FlashCom::View
         timeTextFormat.FontWeight(winrt::WUIT::FontWeights::Bold());
         timeTextFormat.HorizontalAlignment(winrt::MGCT::CanvasHorizontalAlignment::Left);
         auto timeVisual{ CreateTextVisual(m_compositionManager, timeTextFormat, timeText) };
-        timeVisual.AnchorPoint({0.0f, 1.0f}); 
-        timeVisual.RelativeOffsetAdjustment({0.0f, 1.0f, 0.0f}); 
+        timeVisual.AnchorPoint({ 0.0f, 0.0f });
+        timeVisual.RelativeOffsetAdjustment({ 0.0f, 0.0f, 0.0f });
+        timeVisual.Offset({ 28.0f, 0.0f, 0.0f });
 
         auto dateText{ std::format(locale, "{:%x}", time) };
         winrt::MGCT::CanvasTextFormat dateTextFormat;
         dateTextFormat.FontFamily(L"Segoe UI");
-        dateTextFormat.FontSize(32);
+        dateTextFormat.FontSize(48);
         dateTextFormat.FontWeight(winrt::WUIT::FontWeights::Light());
         dateTextFormat.HorizontalAlignment(winrt::MGCT::CanvasHorizontalAlignment::Left);
         auto dateVisual{ CreateTextVisual(m_compositionManager, dateTextFormat, dateText) };
-        dateVisual.AnchorPoint({ 0.0f, 1.0f });
-        dateVisual.RelativeOffsetAdjustment({ 0.0f, 1.0f, 0.0f });
-        // HACK: Until we get text layouts fixed, bump the y position up a
-        // little bit to line it up with the time
-        dateVisual.Offset({ (timeVisual.Size().x + 4.0f), -24.0f, 0.0f });
+        dateVisual.AnchorPoint({ 0.0f, 0.0f });
+        dateVisual.RelativeOffsetAdjustment({ 0.0f, 0.0f, 0.0f });
+        dateVisual.Offset({ 32.0f, (timeVisual.Size().y - 24.0f), 0.0f });
         
         m_clockVisual.Children().RemoveAll();
         m_clockVisual.Children().InsertAtTop(timeVisual);
         m_clockVisual.Children().InsertAtTop(dateVisual);
 
+    }
+
+    void Ui::OnClockUpdateTimerElapsed(winrt::WST::ThreadPoolTimer /*timer*/)
+    {
+        auto nextUpdate{ TimeToNextMinute() };
+        SPDLOG_INFO(
+            "Ui::OnClockUpdateTimerElapsed - Updating clock visual and resetting timer to {}ms",
+            nextUpdate.count());
+        UpdateClockVisual();
+        if (m_clockUpdateTimer)
+        {
+            m_clockUpdateTimer.Cancel();
+            m_clockUpdateTimer = nullptr;
+        }
+        m_clockUpdateTimer = winrt::WST::ThreadPoolTimer::CreateTimer(
+            { this, &Ui::OnClockUpdateTimerElapsed }, nextUpdate);
     }
 #pragma endregion Public
 }

--- a/src/FlashCom/View/Ui.h
+++ b/src/FlashCom/View/Ui.h
@@ -22,13 +22,18 @@ namespace FlashCom::View
         void Update(UpdateReasonKind reason);
 
     private:
+        void UpdateClockVisual();
+
         HostWindow& m_hostWindow;
         Models::DataModel const * const m_dataModel;
         CompositionManager m_compositionManager;
         std::pair<uint32_t, uint32_t> m_uiBounds;
+        // Container visuals
         winrt::Windows::UI::Composition::ContainerVisual m_backgroundVisual{ nullptr };
         winrt::Windows::UI::Composition::ContainerVisual m_contentsVisual{ nullptr };
         winrt::Windows::UI::Composition::ContainerVisual m_rootVisual{ nullptr };
+        // Element visuals
+        winrt::Windows::UI::Composition::ContainerVisual m_clockVisual{ nullptr };
         // Animations
         winrt::Windows::UI::Composition::ScalarKeyFrameAnimation
             m_backgroundFadeInAnimation{ nullptr };

--- a/src/FlashCom/View/Ui.h
+++ b/src/FlashCom/View/Ui.h
@@ -23,6 +23,7 @@ namespace FlashCom::View
 
     private:
         void UpdateClockVisual();
+        void OnClockUpdateTimerElapsed(winrt::Windows::System::Threading::ThreadPoolTimer timer);
 
         HostWindow& m_hostWindow;
         Models::DataModel const * const m_dataModel;
@@ -39,5 +40,7 @@ namespace FlashCom::View
             m_backgroundFadeInAnimation{ nullptr };
         winrt::Windows::UI::Composition::Vector3KeyFrameAnimation
             m_contentScaleInAnimation{ nullptr };
+        // Misc
+        winrt::Windows::System::Threading::ThreadPoolTimer m_clockUpdateTimer{ nullptr };
     };
 }


### PR DESCRIPTION
A local date and time readout has been added to the top left corner of the FlashCom UI, potentially to be made configurable in future releases.

A setting is added to control whether 12 or 24-hour time is shown.