### PR TITLE
🪟 Simplify windowing code, remove clickthrough

### DIFF
--- a/src/FlashCom/View/HostWindow.cpp
+++ b/src/FlashCom/View/HostWindow.cpp
@@ -51,11 +51,11 @@ namespace
         LONG extendedStyles{ GetWindowLongW(hWnd, GWL_EXSTYLE) };
         LONG newStyles
         {
+            // See https://docs.microsoft.com/en-us/windows/win32/winmsg/window-features/
+            // and https://learn.microsoft.com/en-us/windows/win32/winmsg/extended-window-styles
             extendedStyles |
-            WS_EX_LAYERED |    // https://docs.microsoft.com/en-us/windows/win32/winmsg/window-features
             WS_EX_TOOLWINDOW | // Don't show in taskbar/switcher
-            WS_EX_TOPMOST |    // Always on top
-            WS_EX_TRANSPARENT  // Make layered window clickthrough
+            WS_EX_TOPMOST      // Always on top
         };
         SetWindowLongW(hWnd, GWL_EXSTYLE, newStyles);
 


### PR DESCRIPTION
This change simplifies the host window, removing clickthrough and layered support.

This allows the host window to be focused when clicked on as expected by users, and removes the overhead imposed by setting layering and input transparency.